### PR TITLE
[SPT2-204] Add predefined countries in shipping form

### DIFF
--- a/src/components/cart/ShippingInfo.tsx
+++ b/src/components/cart/ShippingInfo.tsx
@@ -9,15 +9,15 @@ import {
   InputLabel,
   SelectChangeEvent,
 } from '@mui/material';
-import { ShippingFormData, ShippingInfoProps } from '@/lib/definitions';
 import { countries } from '@/mock/countries';
+import { City, ShippingFormData, ShippingInfoProps } from '@/lib/definitions';
 
 export default function ShippingInfo({
   shippingInfo,
   setShippingInfo,
   errorMessage,
 }: ShippingInfoProps) {
-  const [cities, setCities] = useState<string[]>([]);
+  const [cities, setCities] = useState<City[]>([]);
   const [states, setStates] = useState<string[]>([]);
 
   useEffect(() => {
@@ -40,7 +40,28 @@ export default function ShippingInfo({
   ) => {
     const name = e.target.name as keyof ShippingFormData;
     const value = e.target.value;
-    setShippingInfo(prev => ({ ...prev, [name]: value }));
+
+    if (name === 'city') {
+      const selectedCity = cities.find(city => city.name === value);
+      if (selectedCity) {
+        setShippingInfo(prev => ({
+          ...prev,
+          [name]: value,
+          zip: selectedCity.zipCode,
+          state: selectedCity.state,
+        }));
+      }
+    } else if (name === 'country') {
+      setShippingInfo(prev => ({
+        ...prev,
+        [name]: value,
+        city: '',
+        state: '',
+        zip: '',
+      }));
+    } else {
+      setShippingInfo(prev => ({ ...prev, [name]: value }));
+    }
   };
 
   return (
@@ -78,8 +99,8 @@ export default function ShippingInfo({
             disabled={!shippingInfo.country}
           >
             {cities.map(city => (
-              <MenuItem key={city} value={city}>
-                {city}
+              <MenuItem key={city.name} value={city.name}>
+                {city.name}
               </MenuItem>
             ))}
           </Select>
@@ -93,7 +114,7 @@ export default function ShippingInfo({
             value={shippingInfo.state}
             onChange={handleChange}
             required
-            disabled={!shippingInfo.country}
+            disabled={true}
           >
             {states.map(state => (
               <MenuItem key={state} value={state}>
@@ -110,6 +131,9 @@ export default function ShippingInfo({
           onChange={handleChange}
           sx={{ width: { xs: '100%', md: '182px' } }}
           required
+          InputProps={{
+            readOnly: true,
+          }}
         />
         <TextField
           variant="outlined"

--- a/src/lib/definitions.ts
+++ b/src/lib/definitions.ts
@@ -154,3 +154,15 @@ export type ShippingInfoProps = {
   setShippingInfo: React.Dispatch<React.SetStateAction<ShippingFormData>>;
   errorMessage: string;
 };
+
+export type City = {
+  name: string;
+  zipCode: string;
+  state: string;
+};
+
+export type Country = {
+  name: string;
+  cities: City[];
+  states: string[];
+};

--- a/src/mock/countries.ts
+++ b/src/mock/countries.ts
@@ -1,19 +1,26 @@
-export const countries = [
+import { Country } from '@/lib/definitions';
+
+export const countries: Country[] = [
   {
     name: 'Argentina',
     cities: [
-      'Buenos Aires',
-      'Córdoba',
-      'Villa Carlos Paz',
-      'Rosario',
-      'Corrientes',
-      'San Martin de los Andes',
+      { name: 'Buenos Aires', zipCode: 'C1000', state: 'Buenos Aires' },
+      { name: 'Córdoba', zipCode: 'X5000', state: 'Córdoba' },
+      { name: 'Villa Carlos Paz', zipCode: 'X5152', state: 'Córdoba' },
+      { name: 'Rosario', zipCode: 'S2000', state: 'Santa Fe' },
+      { name: 'Corrientes', zipCode: 'W3400', state: 'Corrientes' },
+      { name: 'San Martin de los Andes', zipCode: 'Q8370', state: 'Neuquén' },
     ],
-    states: ['Buenos Aires', 'Córdoba', 'Corrientes', 'Neuquén'],
+    states: ['Buenos Aires', 'Córdoba', 'Corrientes', 'Neuquén', 'Santa Fe'],
   },
   {
     name: 'Brazil',
-    cities: ['São Paulo', 'Rio de Janeiro', 'Brasília', 'Florianópolis'],
+    cities: [
+      { name: 'São Paulo', zipCode: '01000-000', state: 'São Paulo' },
+      { name: 'Rio de Janeiro', zipCode: '20000-000', state: 'Rio de Janeiro' },
+      { name: 'Brasília', zipCode: '70000-000', state: 'Distrito Federal' },
+      { name: 'Florianópolis', zipCode: '88000-000', state: 'Santa Catarina' },
+    ],
     states: [
       'São Paulo',
       'Rio de Janeiro',
@@ -23,27 +30,47 @@ export const countries = [
   },
   {
     name: 'Mexico',
-    cities: ['Mexico City', 'Guadalajara', 'Monterrey'],
+    cities: [
+      { name: 'Mexico City', zipCode: '01000', state: 'Mexico City' },
+      { name: 'Guadalajara', zipCode: '44100', state: 'Jalisco' },
+      { name: 'Monterrey', zipCode: '64000', state: 'Nuevo León' },
+    ],
     states: ['Mexico City', 'Jalisco', 'Nuevo León'],
   },
   {
     name: 'United States',
-    cities: ['New York', 'Los Angeles', 'Chicago'],
+    cities: [
+      { name: 'New York', zipCode: '10001', state: 'New York' },
+      { name: 'Los Angeles', zipCode: '90001', state: 'California' },
+      { name: 'Chicago', zipCode: '60601', state: 'Illinois' },
+    ],
     states: ['New York', 'California', 'Illinois'],
   },
   {
     name: 'Poland',
-    cities: ['Warsaw', 'Kraków', 'Łódź'],
+    cities: [
+      { name: 'Warsaw', zipCode: '00-001', state: 'Masovian' },
+      { name: 'Kraków', zipCode: '30-001', state: 'Lesser Poland' },
+      { name: 'Łódź', zipCode: '90-001', state: 'Łódź' },
+    ],
     states: ['Masovian', 'Lesser Poland', 'Łódź'],
   },
   {
     name: 'Ukraine',
-    cities: ['Kyiv', 'Kharkiv', 'Odesa'],
+    cities: [
+      { name: 'Kyiv', zipCode: '01001', state: 'Kyiv Oblast' },
+      { name: 'Kharkiv', zipCode: '61000', state: 'Kharkiv Oblast' },
+      { name: 'Odesa', zipCode: '65000', state: 'Odesa Oblast' },
+    ],
     states: ['Kyiv Oblast', 'Kharkiv Oblast', 'Odesa Oblast'],
   },
   {
     name: 'Georgia',
-    cities: ['Tbilisi', 'Batumi', 'Kutaisi'],
+    cities: [
+      { name: 'Tbilisi', zipCode: '0100', state: 'Tbilisi' },
+      { name: 'Batumi', zipCode: '6000', state: 'Adjara' },
+      { name: 'Kutaisi', zipCode: '4600', state: 'Imereti' },
+    ],
     states: ['Tbilisi', 'Adjara', 'Imereti'],
   },
 ];


### PR DESCRIPTION
# Description
 Add predefined countries, states and cities in Shipping Info form.

## Changes
- [SPT2-204] feat(ShippingInfo.tsx): add predefined countries to select from
- Add mock list of countries in lib/mock folder
- Add type in ShippingInfoProps definition.ts file
- [SPT2-204] chore(ShippingInfo.tsx): state and zip code is completed automatically after selecting a country and city

### Jira
- [SPT2-204](https://solvd-final-project-team-2.atlassian.net/jira/software/projects/SPT2/boards/3?selectedIssue=SPT2-204)

### How to Test
<!-- Provide steps for reviewers to test the changes. Include setup information if necessary. -->
1. Navigate to `<URL or Section>` and perform `<Action>`.
2. Verify that `<Expected Result>` occurs.
3. Run the unit tests by executing `<Command>` and ensure all tests pass.

### Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/63d49d78-dd55-40af-9c9e-dc433364e34f)


### Checklist
<!-- Mark each item with an 'x' if it applies to this pull request. If an item is not applicable, you can leave it unchecked.-->
- [X] Run lint
- [X] Console logs deleted
- [X] My changes generate no new warnings
- [X] My code follows the style guidelines of this project.

### Additional Notes
<!-- Add any additional notes or comments that might be useful for reviewers. -->

[SPT2-204]: https://solvd-final-project-team-2.atlassian.net/browse/SPT2-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SPT2-204]: https://solvd-final-project-team-2.atlassian.net/browse/SPT2-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ